### PR TITLE
Tune bird fall speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A WebAssembly implementation of the classic Flappy Bird game, built with Rust an
 
 - The bird automatically falls due to gravity
 - Press SPACE or click to make the bird flap upward
+- Downward speed is capped so beginners can maintain control
 - Navigate through pipes to score points
 - Each point increases the difficulty by 5%
 - Game ends if the bird hits a pipe or the ground

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, HtmlImageElement};
 
+// Tuning constants for a smoother beginner experience
+const MAX_FALL_SPEED: f64 = 12.0; // Prevent the bird from accelerating too fast
+const BASE_FLAP_STRENGTH: f64 = -8.0; // Baseline upward velocity on flap
+
 // Asset loading
 #[wasm_bindgen]
 extern "C" {
@@ -161,6 +165,9 @@ impl Game {
 
         // Update bird physics with dynamic gravity
         self.bird_velocity += self.get_current_gravity();
+        if self.bird_velocity > MAX_FALL_SPEED {
+            self.bird_velocity = MAX_FALL_SPEED;
+        }
         self.bird_y += self.bird_velocity;
 
         // Update pipes with dynamic speed
@@ -327,7 +334,7 @@ impl Game {
     pub fn flap(&mut self) {
         if self.state == GameState::Playing {
             // Adjust flap strength based on difficulty
-            let flap_strength = -8.0 - (self.get_difficulty_multiplier() - 1.0);
+            let flap_strength = BASE_FLAP_STRENGTH - (self.get_difficulty_multiplier() - 1.0);
             self.bird_velocity = flap_strength;
         }
     }


### PR DESCRIPTION
## Summary
- cap bird fall speed for smoother control
- use a constant for flap strength
- document that downward speed is capped

## Testing
- `cargo fetch` *(fails: could not connect to server)*