### PR TITLE
Add difficulty multiplier integration test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,10 @@ wasm-bindgen-futures = "0.4"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+web-sys = { version = "0.3", features = [
+    "CanvasRenderingContext2d",
+    "Document",
+    "Element",
+    "HtmlCanvasElement",
+    "Window"
+] }

--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ flappy-bird-wasm/
 - No external JavaScript libraries required
 - Pure WebAssembly and vanilla JavaScript implementation
 
+## 🧪 Running Tests
+
+Integration tests are executed with `wasm-bindgen-test`. Ensure the
+`wasm32-unknown-unknown` target is installed and run:
+
+```bash
+cargo test --target wasm32-unknown-unknown -- --nocapture
+```
+
+The included `tests/game_logic.rs` verifies that the game's difficulty
+multiplier never exceeds `2.0` as the score increases.
+
 ## 🎯 Future Improvements
 
 Planned features and enhancements:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ struct Pipe {
 
 impl Game {
     // Helper function to calculate difficulty multiplier based on score
-    fn get_difficulty_multiplier(&self) -> f64 {
+    pub fn get_difficulty_multiplier(&self) -> f64 {
         // Gradually increase difficulty up to a maximum
         let base_multiplier = 1.0 + (self.score as f64 * 0.05);
         base_multiplier.min(2.0) // Cap at 2x difficulty
@@ -146,6 +146,17 @@ impl Game {
             bird_frame: 0,
             frame_count: 0,
         })
+    }
+
+    /// Create a `Game` instance for tests without requiring an existing canvas.
+    #[cfg(test)]
+    pub fn new_headless() -> Result<Game, JsValue> {
+        let window = web_sys::window().expect("no window");
+        let document = window.document().expect("no document");
+        let canvas = document
+            .create_element("canvas")?
+            .dyn_into::<HtmlCanvasElement>()?;
+        Game::new(canvas)
     }
 
     pub async fn load_assets(&mut self) -> Result<(), JsValue> {
@@ -375,6 +386,11 @@ impl Game {
         // Reset to initial game speed and gravity
         self.game_speed = 1.5;
         self.gravity = 0.4;
+    }
+
+    #[cfg(test)]
+    pub fn set_score(&mut self, score: u32) {
+        self.score = score;
     }
 
     fn check_collisions(&mut self) {

--- a/tests/game_logic.rs
+++ b/tests/game_logic.rs
@@ -1,0 +1,14 @@
+use wasm_bindgen_test::*;
+use flappy_bird_wasm::Game;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn difficulty_multiplier_never_exceeds_two() {
+    let mut game = Game::new_headless().unwrap();
+
+    for score in 0..100 {
+        game.set_score(score);
+        assert!(game.get_difficulty_multiplier() <= 2.0);
+    }
+}


### PR DESCRIPTION
## Summary
- expose `get_difficulty_multiplier` to tests
- add a headless constructor and `set_score` helper for tests
- create `wasm_bindgen` integration test covering the difficulty multiplier
- document how to run tests locally

## Testing
- `cargo test --target wasm32-unknown-unknown -- --nocapture` *(fails: Could not connect to server)*